### PR TITLE
Update link to apress site. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apress Source Code
 
-This repository accompanies [*Large Language Models Projects*](https://www.link.springer.com/book/10.1007/979-8-8688-0515-8) by Pere Martra Manonelles (Apress, 2024).
+This repository accompanies [*Large Language Models Projects*](https://link.springer.com/book/10.1007/979-8-8688-0515-8) by Pere Martra Manonelles (Apress, 2024).
 
 [comment]: #cover
 ![Cover image](979-8-8688-0514-1.jpg)


### PR DESCRIPTION
I replaced the link: 
https://www.link.springer.com/book/10.1007/979-8-8688-0515-8 

With: 
https://link.springer.com/chapter/10.1007/979-8-8688-0110-5_4

The first isn't working. 